### PR TITLE
Ase 3.21 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,12 @@ expected to be especially active and follows a simplified Semantic Versioning:
 The changelog format is inspired by [keep-a-changelog](https://github.com/olivierlacan/keep-a-changelog).
 
 ## [Unreleased]
+
+### Fixed
 - ASE > 3.21 compatibility, backwards-compatible to ASE 3.18.
+
+### Changed
+- Atoms method (`atoms.get_reciprocal_cell()`) replaced by Cell method (`atoms.cell.reciprocal()`).
 
 ## [1.1] - 2018-04-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ expected to be especially active and follows a simplified Semantic Versioning:
 The changelog format is inspired by [keep-a-changelog](https://github.com/olivierlacan/keep-a-changelog).
 
 ## [Unreleased]
+- ASE > 3.21 compatibility, backwards-compatible to ASE 3.18.
 
 ## [1.1] - 2018-04-30
 

--- a/kgrid/__init__.py
+++ b/kgrid/__init__.py
@@ -88,7 +88,7 @@ def calc_kpt_tuple_recip(atoms, cutoff_length=10, rounding='up'):
     # Get reciprocal lattice vectors with ASE. Note that ASE does NOT include
     # the 2*pi factor used in many definitions of these vectors; the underlying
     # method is just a matrix inversoin and transposition
-    recip_cell = atoms.get_reciprocal_cell()
+    recip_cell = atoms.cell.reciprocal()
 
     # Get reciprocal cell vector magnitudes according to Pythagoras' theorem
     abc_recip = np.sqrt(np.sum(np.square(recip_cell),1))

--- a/kgrid/series.py
+++ b/kgrid/series.py
@@ -55,7 +55,7 @@ def cutoff_series(atoms, l_min, l_max, decimals=4):
     :returns: Sorted list of cutoffs
     :rtype: list
 """
-    recip_cell = atoms.get_reciprocal_cell()
+    recip_cell = atoms.cell.reciprocal()
     lattice_lengths = np.sqrt(np.sum(np.square(recip_cell), 1))
 
     l0 = get_increments(lattice_lengths)

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ understand and plan calculations with codes that do.
         ],
     keywords='chemistry physics k-point sampling reciprocal',
     packages=find_packages(exclude=['test']),
-    install_requires=['ase'],
+    install_requires=['ase>=3.18'],
     entry_points={
         'console_scripts': [
             'kgrid = kgrid.cli:main',


### PR DESCRIPTION
Using `kgrid-series` with the new version of `ase` will throw a warning:

```python
/home/uccads2/miniconda3/envs/toolbox/lib/python3.9/site-packages/ase/utils/__init__.py:41: FutureWarning: Please use atoms.cell.reciprocal()
  warnings.warn(warning)
```

Fixed by changing to `atoms.get_reciprocal_cell()` to `atoms.cell.reciprocal()`. 
See ASE changelog for version 3.21.0: https://wiki.fysik.dtu.dk/ase/releasenotes.html.
Tested and removes the warning, as well as being backwards-compatible for those using older versions of `ase` (back to 3.18, from July 2019 at least.